### PR TITLE
Ensure thermostat commands reflect UI adjustments immediately

### DIFF
--- a/HomeAssistantClimate/Definitions/DeviceUxCategory.cs
+++ b/HomeAssistantClimate/Definitions/DeviceUxCategory.cs
@@ -1,0 +1,258 @@
+﻿using Crestron.DeviceDrivers.SDK.EntityModel.Attributes;
+
+namespace Definitions
+{
+    [EntityDataType(Id = "crestron:DeviceUxCategory")]
+    public enum DeviceUxCategory
+    {
+        /// <summary>
+        ///     The device did not fit into any of the predefined categories
+        /// </summary>
+        Other,
+
+        /// <summary>
+        ///     The device is primarily an audio amplifier
+        /// </summary>
+        Amplifier,
+
+        /// <summary>
+        ///     The device is primarily an appliance, such as a stove, oven, coffee maker,
+        ///     microwave, dishwasher, or similar device.
+        /// </summary>
+        Appliance,
+
+        /// <summary>
+        ///     The device represents an area, rolling up any states and control for the devices and
+        ///     rooms in the area to an area-level API.
+        ///     An area is defined as a space (physical or virtual) that may be stateful and
+        ///     controllable as a whole, composed of devices, rooms, and nested areas (which may or
+        ///     may not be listed) that belong to that area. A device, room, or area may only be
+        ///     directly contained by one parent area. A hierarchy of areas, rooms, and devices is
+        ///     like a tree structure where each node has a single parent.
+        /// </summary>
+        Area,
+
+        /// <summary>
+        ///     The device is primarily an audio mixer
+        /// </summary>
+        AudioMixer,
+
+        /// <summary>
+        ///     The device is primarily an audio processor / pre-amp
+        /// </summary>
+        AudioProcessor,
+
+        /// <summary>
+        ///     The device is primarily an Audio/Video Receiver (AVR)
+        /// </summary>
+        AvReceiver,
+
+        /// <summary>
+        ///     The device is primarily an Audio/Video Switcher
+        /// </summary>
+        AvSwitcher,
+
+        /// <summary>
+        ///     The device is primarily an Audio Switcher
+        /// </summary>
+        AudioSwitcher,
+
+        /// <summary>
+        ///     The device is primarily a Bluray player
+        /// </summary>
+        BlurayPlayer,
+
+        /// <summary>
+        ///     The device is primarily a Cable Box (as in the cable signal receiver for a TV, not a
+        ///     storage crate for wires)
+        /// </summary>
+        CableBox,
+
+        /// <summary>
+        ///     The device is primarily a camera, usually with PTZ (pan, tilt, zoom) capabilities
+        /// </summary>
+        Camera,
+
+        /// <summary>
+        ///     The device is primarily a video display device
+        /// </summary>
+        Display,
+
+        /// <summary>
+        ///     The device is primarily a fan
+        /// </summary>
+        Fan,
+
+        /// <summary>
+        ///     The device is primarily a fireplace
+        /// </summary>
+        Fireplace,
+
+        /// <summary>
+        ///     The device is primarily a video game console, such as an XBOX, PlayStation, or
+        ///     Nintendo.
+        /// </summary>
+        GameConsole,
+
+        /// <summary>
+        ///     The device is primarily a garage door
+        /// </summary>
+        GarageDoor,
+
+        /// <summary>
+        ///     The device represents a group of entites, rolling up any states and control for
+        ///     members of the group to a group-level API.
+        ///     Groups may overlap, contain other groups, and contain devices from various rooms and
+        ///     areas.
+        /// </summary>
+        Group,
+
+        /// <summary>
+        ///     The device is primarily an HVAC device, like a thermostat, heating / air
+        ///     conditioning system, humidifier, dehumidifier, or similar device.
+        /// </summary>
+        Hvac,
+
+        /// <summary>
+        ///     The device is primarily an intercom system
+        /// </summary>
+        Intercom,
+
+        /// <summary>
+        ///     The device is primarily an irrigation system, such as a lawn sprinkler system or
+        ///     garden irrigation system
+        /// </summary>
+        IrrigationSystem,
+
+        /// <summary>
+        ///     The device is primarily a lighting device
+        /// </summary>
+        Light,
+
+        /// <summary>
+        ///     The device is primarily a lock, such as a door lock or other electronic lock
+        /// </summary>
+        Lock,
+
+        /// <summary>
+        ///     The device is primarily a network router device
+        /// </summary>
+        NetworkRouter,
+
+        /// <summary>
+        ///     The device is primarily a network (ethernet) switch
+        /// </summary>
+        NetworkSwitch,
+
+        /// <summary>
+        ///     The device is primarily a smart power outlet / smart plug
+        /// </summary>
+        Outlet,
+
+        /// <summary>
+        ///     The device is primarily a "platform" for other devices, like a gateway to another
+        ///     ecosystem of devices
+        /// </summary>
+        Platform,
+
+        /// <summary>
+        ///     The device is a pool, typically contained in and controlled by a pool controller
+        ///     device. This device is the representation of the pool itself.
+        /// </summary>
+        Pool,
+
+        /// <summary>
+        ///     The device is a controller for a pool system, typically containing a pool and/or spa
+        ///     device, as well as other devices
+        /// </summary>
+        PoolController,
+
+        /// <summary>
+        ///     The device is primarily a power controller / power distribution unit (PDU)
+        /// </summary>
+        PowerController,
+
+        /// <summary>
+        ///     The device is primarily a document printer
+        /// </summary>
+        Printer,
+
+        /// <summary>
+        ///     The device is primarily a video projector device
+        /// </summary>
+        Projector,
+
+        /// <summary>
+        ///     The device is primarily a lift for a video projector
+        /// </summary>
+        ProjectorLift,
+
+        /// <summary>
+        ///     The device is primarily a projector screen
+        /// </summary>
+        ProjectorScreen,
+
+        /// <summary>
+        ///     The device represents a room, rolling up any states and control for the devices in
+        ///     the room to a room-level API.
+        ///     A room is defined as a space (physical or virtual) that may be stateful and
+        ///     controllable as a whole, composed of devices (which may or may not be listed by the
+        ///     room) that belong to that room. A device may only be in one room, and a room may not
+        ///     contain other rooms.
+        /// </summary>
+        Room,
+
+        /// <summary>
+        ///     The device is primarily a document scanner
+        /// </summary>
+        Scanner,
+
+        /// <summary>
+        ///     The device is primarily a security system
+        /// </summary>
+        SecuritySystem,
+
+        /// <summary>
+        ///     The device is primarily a sensor device, such as a door sensor, occupancy sensor,
+        ///     light sensor, etc.
+        /// </summary>
+        Sensor,
+
+        /// <summary>
+        ///     The device is primarily a window shade, curtain, drapes, etc.
+        /// </summary>
+        Shade,
+
+        /// <summary>
+        ///     The device is a spa/hot tub, typically contained in and controlled by a pool
+        ///     controller device. This device is the representation of the spa itself.
+        /// </summary>
+        Spa,
+
+        /// <summary>
+        ///     The device is primarily a speaker
+        /// </summary>
+        Speaker,
+
+        /// <summary>
+        ///     The device is primarily a vacuum cleaner, typically an automatic robotic vacuum, or
+        ///     a pool vacuum
+        /// </summary>
+        Vacuum,
+
+        /// <summary>
+        ///     The device is primarily a vehicle
+        /// </summary>
+        Vehicle,
+
+        /// <summary>
+        ///     The device is primarily a Codec device for video conferencing
+        /// </summary>
+        VideoConferenceCodec,
+
+        /// <summary>
+        ///     The device is primarily a Video Server, like an Apple TV, Roku, etc.
+        /// </summary>
+        VideoServer
+    }
+}

--- a/HomeAssistantClimate/Definitions/PlatformManagedDevice.cs
+++ b/HomeAssistantClimate/Definitions/PlatformManagedDevice.cs
@@ -1,0 +1,51 @@
+﻿#region Copyright
+
+// ---------------------------------------------------------------------------
+// Copyright © 2023 to the present, Crestron Electronics®, Inc.
+// All Rights Reserved.
+// No part of this software may be reproduced in any form, machine
+// or natural, without the express written consent of Crestron Electronics.
+// Use of this source code is subject to the terms of the Crestron Software
+// License Agreement under which you licensed this source code.
+// ---------------------------------------------------------------------------
+
+#endregion
+
+using Crestron.DeviceDrivers.SDK.EntityModel.Attributes;
+
+namespace Definitions
+{
+    [EntityDataType(Id = "platform:ManagedDevice")]
+    public class PlatformManagedDevice
+    {
+        public PlatformManagedDevice(
+            DeviceUxCategory uxCategory,
+            string name,
+            string manufacturer,
+            string model,
+            string serialNumber
+        )
+        {
+            UxCategory = uxCategory;
+            Name = name;
+            Manufacturer = manufacturer;
+            Model = model;
+            SerialNumber = serialNumber;
+        }
+
+        [EntityProperty]
+        public DeviceUxCategory UxCategory { get; private set; }
+
+        [EntityProperty]
+        public string Name { get; private set; }
+
+        [EntityProperty]
+        public string Manufacturer { get; private set; }
+
+        [EntityProperty]
+        public string Model { get; private set; }
+
+        [EntityProperty]
+        public string SerialNumber { get; private set; }
+    }
+}

--- a/HomeAssistantClimate/Devices/HomeAssistantClimateDevice.cs
+++ b/HomeAssistantClimate/Devices/HomeAssistantClimateDevice.cs
@@ -1,0 +1,279 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Crestron.DeviceDrivers.EntityModel;
+using Crestron.DeviceDrivers.EntityModel.Data;
+using Crestron.DeviceDrivers.SDK.EntityModel;
+using Crestron.DeviceDrivers.SDK.EntityModel.Attributes;
+using HomeAssistantClimate.Gateway;
+
+namespace HomeAssistantClimate.Devices
+{
+    public sealed class HomeAssistantClimateDevice : ReflectedAttributeDriverEntity, IDisposable
+    {
+        private readonly string _friendlyName;
+        private readonly HomeAssistantGateway _gateway;
+        private readonly object _syncRoot = new object();
+
+        private double? _currentTemp;
+        private double? _targetTemp;
+        private double? _targetLow;
+        private double? _targetHigh;
+        private double? _humidity;
+        private string _hvacMode = "off";
+        private string _action = string.Empty;
+        private IReadOnlyList<string> _availableModes = Array.Empty<string>();
+        private bool _isConnected;
+
+        public HomeAssistantClimateDevice(string entityId, string friendlyName, HomeAssistantGateway gateway)
+            : base(entityId)
+        {
+            _friendlyName = friendlyName;
+            _gateway = gateway;
+        }
+
+        [EntityProperty(Id = "climate:friendlyName")]
+        public string FriendlyName => _friendlyName;
+
+        [EntityProperty(Id = "climate:isConnected")]
+        public bool IsConnected => _isConnected;
+
+        [EntityProperty(Id = "climate:currentTemperature")]
+        public double? CurrentTemperature => _currentTemp;
+
+        [EntityProperty(Id = "climate:targetTemperature")]
+        public double? TargetTemperature => _targetTemp;
+
+        [EntityProperty(Id = "climate:targetTempLow")]
+        public double? TargetTemperatureLow => _targetLow;
+
+        [EntityProperty(Id = "climate:targetTempHigh")]
+        public double? TargetTemperatureHigh => _targetHigh;
+
+        [EntityProperty(Id = "climate:humidity")]
+        public double? Humidity => _humidity;
+
+        [EntityProperty(Id = "climate:hvacMode")]
+        public string HvacMode => _hvacMode;
+
+        [EntityProperty(Id = "climate:hvacAction")]
+        public string Action => _action;
+
+        [EntityProperty(Id = "climate:availableHvacModes")]
+        public string AvailableHvacModes => string.Join(", ", _availableModes ?? Array.Empty<string>());
+
+        [EntityCommand(Id = "climate:setTargetTemperature")]
+        public void SetTargetTemperature(DriverEntityValue? value)
+        {
+            if (!TryGetDouble(value, out var newTemp))
+            {
+                return;
+            }
+
+            UpdateProperty(ref _targetTemp, newTemp, "climate:targetTemperature");
+            _ = Task.Run(() => _gateway.SetTargetTemperatureAsync(ControllerId, newTemp, null, null, CancellationToken.None));
+        }
+
+        [EntityCommand(Id = "climate:setTargetTempLow")]
+        public void SetTargetTempLow(DriverEntityValue? value)
+        {
+            if (!TryGetDouble(value, out var low))
+            {
+                return;
+            }
+
+            UpdateProperty(ref _targetLow, low, "climate:targetTempLow");
+            _ = Task.Run(() => _gateway.SetTargetTemperatureAsync(ControllerId, null, _targetLow, _targetHigh, CancellationToken.None));
+        }
+
+        [EntityCommand(Id = "climate:setTargetTempHigh")]
+        public void SetTargetTempHigh(DriverEntityValue? value)
+        {
+            if (!TryGetDouble(value, out var high))
+            {
+                return;
+            }
+
+            UpdateProperty(ref _targetHigh, high, "climate:targetTempHigh");
+            _ = Task.Run(() => _gateway.SetTargetTemperatureAsync(ControllerId, null, _targetLow, _targetHigh, CancellationToken.None));
+        }
+
+        [EntityCommand(Id = "climate:setHvacMode")]
+        public void SetHvacMode(DriverEntityValue? modeValue)
+        {
+            var mode = TryGetString(modeValue);
+            if (mode == null)
+            {
+                return;
+            }
+
+            UpdateProperty(ref _hvacMode, mode, "climate:hvacMode");
+            _ = Task.Run(() => _gateway.SetHvacModeAsync(ControllerId, mode, CancellationToken.None));
+        }
+
+        [EntityCommand(Id = "climate:setPresetMode")]
+        public void SetPresetMode(DriverEntityValue? presetValue)
+        {
+            var preset = TryGetString(presetValue);
+            if (preset == null)
+            {
+                return;
+            }
+
+            _ = Task.Run(() => _gateway.SetPresetModeAsync(ControllerId, preset, CancellationToken.None));
+        }
+
+        [EntityCommand(Id = "climate:setFanMode")]
+        public void SetFanMode(DriverEntityValue? modeValue)
+        {
+            var mode = TryGetString(modeValue);
+            if (mode == null)
+            {
+                return;
+            }
+
+            _ = Task.Run(() => _gateway.SetFanModeAsync(ControllerId, mode, CancellationToken.None));
+        }
+
+        [EntityCommand(Id = "climate:increaseSetpoint")]
+        public void IncreaseSetpoint()
+        {
+            var newTarget = (_targetTemp ?? _currentTemp ?? 70.0) + 0.5;
+            UpdateProperty(ref _targetTemp, newTarget, "climate:targetTemperature");
+            _ = Task.Run(() => _gateway.SetTargetTemperatureAsync(ControllerId, newTarget, null, null, CancellationToken.None));
+        }
+
+        [EntityCommand(Id = "climate:decreaseSetpoint")]
+        public void DecreaseSetpoint()
+        {
+            var newTarget = (_targetTemp ?? _currentTemp ?? 70.0) - 0.5;
+            UpdateProperty(ref _targetTemp, newTarget, "climate:targetTemperature");
+            _ = Task.Run(() => _gateway.SetTargetTemperatureAsync(ControllerId, newTarget, null, null, CancellationToken.None));
+        }
+
+        public void SetConnectionState(bool connected)
+        {
+            UpdateProperty(ref _isConnected, connected, "climate:isConnected");
+        }
+
+        public void UpdateFromState(ClimateDeviceState state)
+        {
+            if (state == null)
+            {
+                return;
+            }
+
+            UpdateProperty(ref _currentTemp, state.CurrentTemperature, "climate:currentTemperature");
+            UpdateProperty(ref _targetTemp, state.TargetTemperature, "climate:targetTemperature");
+            UpdateProperty(ref _targetLow, state.TargetTemperatureLow, "climate:targetTempLow");
+            UpdateProperty(ref _targetHigh, state.TargetTemperatureHigh, "climate:targetTempHigh");
+            UpdateProperty(ref _humidity, state.Humidity, "climate:humidity");
+            UpdateProperty(ref _hvacMode, state.HvacMode, "climate:hvacMode");
+            UpdateProperty(ref _action, state.Action, "climate:hvacAction");
+            UpdateModes(state.HvacModes);
+        }
+
+        private void UpdateModes(IReadOnlyList<string> modes)
+        {
+            lock (_syncRoot)
+            {
+                if (modes == null)
+                {
+                    modes = Array.Empty<string>();
+                }
+
+                if (_availableModes == null || !AreModesEqual(_availableModes, modes))
+                {
+                    _availableModes = modes;
+                    NotifyPropertyChanged("climate:availableHvacModes", CreateValueForObject(AvailableHvacModes));
+                }
+            }
+        }
+
+        private static bool AreModesEqual(IReadOnlyList<string> first, IReadOnlyList<string> second)
+        {
+            if (first == null && second == null)
+            {
+                return true;
+            }
+
+            if (first == null || second == null)
+            {
+                return false;
+            }
+
+            if (first.Count != second.Count)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < first.Count; i++)
+            {
+                if (!string.Equals(first[i], second[i], StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private void UpdateProperty<T>(ref T field, T value, string propertyId)
+        {
+            if (EqualityComparer<T>.Default.Equals(field, value))
+            {
+                return;
+            }
+
+            field = value;
+            NotifyPropertyChanged(propertyId, CreateValueForObject(value));
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
+        }
+
+        private static bool TryGetDouble(DriverEntityValue? value, out double result)
+        {
+            result = default;
+
+            if (!value.HasValue)
+            {
+                return false;
+            }
+
+            var raw = value.Value.GetValue<object>();
+            if (raw == null)
+            {
+                return false;
+            }
+
+            try
+            {
+                result = Convert.ToDouble(raw);
+                return true;
+            }
+            catch (FormatException)
+            {
+                return false;
+            }
+            catch (InvalidCastException)
+            {
+                return false;
+            }
+        }
+
+        private static string TryGetString(DriverEntityValue? value)
+        {
+            if (!value.HasValue)
+            {
+                return null;
+            }
+
+            var raw = value.Value.GetValue<object>();
+            return raw?.ToString();
+        }
+    }
+}

--- a/HomeAssistantClimate/EntryPoint.cs
+++ b/HomeAssistantClimate/EntryPoint.cs
@@ -1,0 +1,21 @@
+using Crestron.DeviceDrivers.EntityModel;
+using Crestron.DeviceDrivers.SDK;
+using Crestron.DeviceDrivers.SDK.EntityModel;
+
+[assembly: DriverAssemblyEntryPoint(typeof(HomeAssistantClimate.EntryPoint))]
+
+namespace HomeAssistantClimate
+{
+    public sealed class EntryPoint : DriverAssemblyEntryPoint
+    {
+        public override DriverController CreateDriverControllerInstance(DriverControllerCreationArgs args)
+        {
+            var resources = DriverImplementationResources.FromCreationArgs(args, typeof(EntryPoint));
+
+            var platform = new HomeAssistantPlatform(args, resources);
+            var entity = new ConfigurableDriverEntity(platform.ControllerId, platform, platform.ConfigurationController);
+
+            return new DispatchingDeviceController(entity, args, null);
+        }
+    }
+}

--- a/HomeAssistantClimate/Gateway/HomeAssistantGateway.cs
+++ b/HomeAssistantClimate/Gateway/HomeAssistantGateway.cs
@@ -1,0 +1,434 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.WebSockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+
+namespace HomeAssistantClimate.Gateway
+{
+    public sealed class HomeAssistantGateway : IDisposable
+    {
+        private readonly Uri _webSocketUri;
+        private readonly string _token;
+        private readonly ConcurrentDictionary<int, TaskCompletionSource<JToken>> _pendingRequests = new ConcurrentDictionary<int, TaskCompletionSource<JToken>>();
+        private readonly ConcurrentDictionary<string, ClimateDeviceState> _knownClimateDevices = new ConcurrentDictionary<string, ClimateDeviceState>(StringComparer.OrdinalIgnoreCase);
+        private readonly SemaphoreSlim _sendLock = new SemaphoreSlim(1, 1);
+
+        private ClientWebSocket _client;
+        private CancellationTokenSource _internalTokenSource;
+        private Task _receiveLoop;
+        private int _messageId;
+        private bool _disposed;
+
+        public HomeAssistantGateway(Uri webSocketUri, string token)
+        {
+            _webSocketUri = webSocketUri ?? throw new ArgumentNullException(nameof(webSocketUri));
+            _token = token ?? throw new ArgumentNullException(nameof(token));
+        }
+
+        public event EventHandler<bool> ConnectionStateChanged;
+        public event EventHandler<ClimateDeviceDiscoveredEventArgs> ClimateDeviceDiscovered;
+        public event EventHandler<ClimateDeviceUpdatedEventArgs> ClimateDeviceUpdated;
+        public event EventHandler<ClimateDeviceRemovedEventArgs> ClimateDeviceRemoved;
+
+        public async Task StartAsync(CancellationToken cancellationToken)
+        {
+            using (var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
+            {
+                while (!linkedCts.IsCancellationRequested)
+                {
+                    try
+                    {
+                        await ConnectAndRunAsync(linkedCts.Token).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        break;
+                    }
+                    catch (Exception)
+                    {
+                        ConnectionStateChanged?.Invoke(this, false);
+                        await Task.Delay(TimeSpan.FromSeconds(5), linkedCts.Token).ConfigureAwait(false);
+                    }
+                }
+            }
+        }
+
+        public async Task SetTargetTemperatureAsync(string entityId, double? target, double? low, double? high, CancellationToken cancellationToken)
+        {
+            var data = new Dictionary<string, JToken>();
+            if (target.HasValue)
+            {
+                data["temperature"] = JToken.FromObject(target.Value);
+            }
+
+            if (low.HasValue)
+            {
+                data["target_temp_low"] = JToken.FromObject(low.Value);
+            }
+
+            if (high.HasValue)
+            {
+                data["target_temp_high"] = JToken.FromObject(high.Value);
+            }
+
+            if (data.Count == 0)
+            {
+                return;
+            }
+
+            await SendServiceCommandAsync("climate", entityId, "set_temperature", data, cancellationToken).ConfigureAwait(false);
+        }
+
+        public Task SetHvacModeAsync(string entityId, string mode, CancellationToken cancellationToken)
+        {
+            var data = new Dictionary<string, JToken>
+            {
+                { "hvac_mode", mode }
+            };
+
+            return SendServiceCommandAsync("climate", entityId, "set_hvac_mode", data, cancellationToken);
+        }
+
+        public Task SetPresetModeAsync(string entityId, string preset, CancellationToken cancellationToken)
+        {
+            var data = new Dictionary<string, JToken>
+            {
+                { "preset_mode", preset }
+            };
+
+            return SendServiceCommandAsync("climate", entityId, "set_preset_mode", data, cancellationToken);
+        }
+
+        public Task SetFanModeAsync(string entityId, string mode, CancellationToken cancellationToken)
+        {
+            var data = new Dictionary<string, JToken>
+            {
+                { "fan_mode", mode }
+            };
+
+            return SendServiceCommandAsync("climate", entityId, "set_fan_mode", data, cancellationToken);
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            _internalTokenSource?.Cancel();
+            _internalTokenSource?.Dispose();
+            _client?.Dispose();
+            _sendLock.Dispose();
+        }
+
+        private async Task ConnectAndRunAsync(CancellationToken cancellationToken)
+        {
+            _internalTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+            _knownClimateDevices.Clear();
+
+            _client?.Dispose();
+            _client = new ClientWebSocket();
+            _client.Options.KeepAliveInterval = TimeSpan.FromSeconds(15);
+
+            await _client.ConnectAsync(_webSocketUri, cancellationToken).ConfigureAwait(false);
+
+            var authHandshake = await ReceiveMessageAsync(cancellationToken).ConfigureAwait(false);
+            if (authHandshake == null)
+            {
+                throw new IOException("Connection closed during authentication");
+            }
+
+            var messageType = authHandshake.Value<string>("type");
+            if (string.Equals(messageType, "auth_required", StringComparison.OrdinalIgnoreCase))
+            {
+                await SendAsync(HomeAssistantMessageFactory.CreateAuthMessage(_token), cancellationToken).ConfigureAwait(false);
+                authHandshake = await ReceiveMessageAsync(cancellationToken).ConfigureAwait(false);
+                messageType = authHandshake.Value<string>("type");
+            }
+
+            if (!string.Equals(messageType, "auth_ok", StringComparison.OrdinalIgnoreCase))
+            {
+                if (string.Equals(messageType, "auth_invalid", StringComparison.OrdinalIgnoreCase))
+                {
+                    var message = authHandshake.Value<string>("message") ?? "Authentication failed";
+                    throw new InvalidOperationException(message);
+                }
+
+                throw new InvalidOperationException($"Unexpected authentication response '{messageType}'");
+            }
+
+            ConnectionStateChanged?.Invoke(this, true);
+
+            _receiveLoop = Task.Run(() => ReceiveLoopAsync(_internalTokenSource.Token), _internalTokenSource.Token);
+
+            await SendAsync(HomeAssistantMessageFactory.CreateSubscribeStateChangesMessage(GetMessageId()), cancellationToken).ConfigureAwait(false);
+
+            var statesToken = await SendRequestAsync(HomeAssistantMessageFactory.CreateGetStatesMessage(GetMessageId()), cancellationToken).ConfigureAwait(false);
+            if (statesToken is JArray array)
+            {
+                ProcessInitialStates(array);
+            }
+
+            await _receiveLoop.ConfigureAwait(false);
+        }
+
+        private async Task ReceiveLoopAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    var message = await ReceiveMessageAsync(cancellationToken).ConfigureAwait(false);
+                    if (message == null)
+                    {
+                        break;
+                    }
+
+                    var type = message.Value<string>("type");
+                    switch (type)
+                    {
+                        case "event":
+                            HandleEventMessage(message);
+                            break;
+                        case "result":
+                            HandleResultMessage(message);
+                            break;
+                        case "pong":
+                            break;
+                        default:
+                            break;
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            finally
+            {
+                ConnectionStateChanged?.Invoke(this, false);
+                _internalTokenSource?.Cancel();
+            }
+        }
+
+        private void HandleResultMessage(JObject message)
+        {
+            var id = message.Value<int?>("id");
+            if (id == null)
+            {
+                return;
+            }
+
+            if (_pendingRequests.TryRemove(id.Value, out var tcs))
+            {
+                var success = message.Value<bool?>("success") ?? true;
+                if (!success)
+                {
+                    var error = message.Value<JObject>("error");
+                    tcs.TrySetException(new InvalidOperationException(error?.Value<string>("message") ?? "Home Assistant error"));
+                }
+                else
+                {
+                    tcs.TrySetResult(message["result"]);
+                }
+            }
+        }
+
+        private void HandleEventMessage(JObject message)
+        {
+            var @event = message.Value<JObject>("event");
+            if (@event == null)
+            {
+                return;
+            }
+
+            var eventType = @event.Value<string>("event_type");
+            if (!string.Equals(eventType, "state_changed", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            var data = @event.Value<JObject>("data");
+            var entityId = data?.Value<string>("entity_id");
+            if (string.IsNullOrEmpty(entityId) || !entityId.StartsWith("climate.", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            var newState = data.Value<JObject>("new_state");
+            if (newState == null)
+            {
+                if (_knownClimateDevices.TryRemove(entityId, out _))
+                {
+                    ClimateDeviceRemoved?.Invoke(this, new ClimateDeviceRemovedEventArgs(entityId));
+                }
+
+                return;
+            }
+
+            var parsedState = ParseClimateState(newState);
+            if (parsedState == null)
+            {
+                return;
+            }
+
+            var isNew = !_knownClimateDevices.ContainsKey(entityId);
+            _knownClimateDevices[entityId] = parsedState;
+
+            if (isNew)
+            {
+                ClimateDeviceDiscovered?.Invoke(this, new ClimateDeviceDiscoveredEventArgs(entityId, parsedState.FriendlyName, parsedState.Model, parsedState));
+            }
+            else
+            {
+                ClimateDeviceUpdated?.Invoke(this, new ClimateDeviceUpdatedEventArgs(entityId, parsedState));
+            }
+        }
+
+        private void ProcessInitialStates(JArray array)
+        {
+            foreach (var token in array.OfType<JObject>())
+            {
+                var state = ParseClimateState(token);
+                if (state == null)
+                {
+                    continue;
+                }
+
+                if (_knownClimateDevices.TryAdd(state.EntityId, state))
+                {
+                    ClimateDeviceDiscovered?.Invoke(this, new ClimateDeviceDiscoveredEventArgs(state.EntityId, state.FriendlyName, state.Model, state));
+                }
+                else
+                {
+                    ClimateDeviceUpdated?.Invoke(this, new ClimateDeviceUpdatedEventArgs(state.EntityId, state));
+                }
+            }
+        }
+
+        private ClimateDeviceState ParseClimateState(JObject state)
+        {
+            var entityId = state.Value<string>("entity_id");
+            if (string.IsNullOrEmpty(entityId) || !entityId.StartsWith("climate.", StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            var attributes = state.Value<JObject>("attributes") ?? new JObject();
+            var friendlyName = attributes.Value<string>("friendly_name") ?? entityId;
+            var model = attributes.Value<string>("model") ?? "HA Climate";
+            var hvacModes = attributes.Value<JArray>("hvac_modes")?.Select(x => x.Value<string>()).Where(x => !string.IsNullOrWhiteSpace(x)).ToList() ?? new List<string>();
+
+            var parsed = new ClimateDeviceState
+            {
+                EntityId = entityId,
+                FriendlyName = friendlyName,
+                Model = model,
+                CurrentTemperature = attributes.Value<double?>("current_temperature"),
+                TargetTemperature = attributes.Value<double?>("temperature"),
+                TargetTemperatureLow = attributes.Value<double?>("target_temp_low"),
+                TargetTemperatureHigh = attributes.Value<double?>("target_temp_high"),
+                HvacMode = state.Value<string>("state"),
+                HvacModes = hvacModes,
+                Action = attributes.Value<string>("hvac_action") ?? attributes.Value<string>("action"),
+                Humidity = attributes.Value<double?>("current_humidity"),
+                LastUpdated = state.Value<DateTimeOffset?>("last_updated") ?? DateTimeOffset.UtcNow
+            };
+
+            return parsed;
+        }
+
+        private async Task<JObject> ReceiveMessageAsync(CancellationToken cancellationToken)
+        {
+            var buffer = new ArraySegment<byte>(new byte[8192]);
+            using (var ms = new MemoryStream())
+            {
+                while (true)
+                {
+                    var result = await _client.ReceiveAsync(buffer, cancellationToken).ConfigureAwait(false);
+                    if (result.MessageType == WebSocketMessageType.Close)
+                    {
+                        await _client.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, cancellationToken).ConfigureAwait(false);
+                        return null;
+                    }
+
+                    ms.Write(buffer.Array, buffer.Offset, result.Count);
+
+                    if (result.EndOfMessage)
+                    {
+                        break;
+                    }
+                }
+
+                var json = Encoding.UTF8.GetString(ms.ToArray());
+                if (string.IsNullOrWhiteSpace(json))
+                {
+                    return null;
+                }
+
+                return JObject.Parse(json);
+            }
+        }
+
+        private async Task SendAsync(JObject message, CancellationToken cancellationToken)
+        {
+            var payload = Encoding.UTF8.GetBytes(message.ToString());
+            await _sendLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await _client.SendAsync(new ArraySegment<byte>(payload), WebSocketMessageType.Text, true, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                _sendLock.Release();
+            }
+        }
+
+        private async Task<JToken> SendRequestAsync(JObject message, CancellationToken cancellationToken)
+        {
+            var id = message.Value<int>("id");
+            var tcs = new TaskCompletionSource<JToken>(TaskCreationOptions.RunContinuationsAsynchronously);
+            if (!_pendingRequests.TryAdd(id, tcs))
+            {
+                throw new InvalidOperationException("Duplicate message id");
+            }
+
+            try
+            {
+                await SendAsync(message, cancellationToken).ConfigureAwait(false);
+                using (var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30)))
+                using (var linked = CancellationTokenSource.CreateLinkedTokenSource(timeout.Token, cancellationToken))
+                {
+                    using (linked.Token.Register(() => tcs.TrySetCanceled(), useSynchronizationContext: false))
+                    {
+                        return await tcs.Task.ConfigureAwait(false);
+                    }
+                }
+            }
+            finally
+            {
+                _pendingRequests.TryRemove(id, out _);
+            }
+        }
+
+        private async Task SendServiceCommandAsync(string domain, string entityId, string service, IDictionary<string, JToken> serviceData, CancellationToken cancellationToken)
+        {
+            var id = GetMessageId();
+            var message = HomeAssistantMessageFactory.CreateCallServiceMessage(id, domain, entityId, service, serviceData);
+            await SendAsync(message, cancellationToken).ConfigureAwait(false);
+        }
+
+        private int GetMessageId()
+        {
+            return Interlocked.Increment(ref _messageId);
+        }
+    }
+}

--- a/HomeAssistantClimate/Gateway/HomeAssistantMessageFactory.cs
+++ b/HomeAssistantClimate/Gateway/HomeAssistantMessageFactory.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+
+namespace HomeAssistantClimate.Gateway
+{
+    internal static class HomeAssistantMessageFactory
+    {
+        public static JObject CreateAuthMessage(string token)
+        {
+            return new JObject
+            {
+                ["type"] = "auth",
+                ["access_token"] = token
+            };
+        }
+
+        public static JObject CreateSubscribeStateChangesMessage(int id)
+        {
+            return new JObject
+            {
+                ["id"] = id,
+                ["type"] = "subscribe_events",
+                ["event_type"] = "state_changed"
+            };
+        }
+
+        public static JObject CreateGetStatesMessage(int id)
+        {
+            return new JObject
+            {
+                ["id"] = id,
+                ["type"] = "get_states"
+            };
+        }
+
+        public static JObject CreateCallServiceMessage(int id, string domain, string entityId, string service, IDictionary<string, JToken> data)
+        {
+            var payload = new JObject
+            {
+                ["id"] = id,
+                ["type"] = "call_service",
+                ["domain"] = domain,
+                ["service"] = service,
+                ["target"] = new JObject { ["entity_id"] = entityId },
+                ["service_data"] = new JObject()
+            };
+
+            if (data != null)
+            {
+                foreach (var kvp in data)
+                {
+                    payload.Value<JObject>("service_data")[kvp.Key] = kvp.Value;
+                }
+            }
+
+            return payload;
+        }
+    }
+}

--- a/HomeAssistantClimate/Gateway/HomeAssistantModels.cs
+++ b/HomeAssistantClimate/Gateway/HomeAssistantModels.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+
+namespace HomeAssistantClimate.Gateway
+{
+    public class ClimateDeviceState
+    {
+        public string EntityId { get; set; }
+        public string FriendlyName { get; set; }
+        public string Model { get; set; }
+        public double? CurrentTemperature { get; set; }
+        public double? TargetTemperature { get; set; }
+        public double? TargetTemperatureLow { get; set; }
+        public double? TargetTemperatureHigh { get; set; }
+        public string HvacMode { get; set; }
+        public IReadOnlyList<string> HvacModes { get; set; }
+        public string Action { get; set; }
+        public double? Humidity { get; set; }
+        public DateTimeOffset LastUpdated { get; set; }
+    }
+
+    public sealed class ClimateDeviceDiscoveredEventArgs : EventArgs
+    {
+        public ClimateDeviceDiscoveredEventArgs(string entityId, string friendlyName, string model, ClimateDeviceState state)
+        {
+            EntityId = entityId;
+            FriendlyName = friendlyName;
+            Model = model;
+            State = state;
+        }
+
+        public string EntityId { get; }
+        public string FriendlyName { get; }
+        public string Model { get; }
+        public ClimateDeviceState State { get; }
+    }
+
+    public sealed class ClimateDeviceUpdatedEventArgs : EventArgs
+    {
+        public ClimateDeviceUpdatedEventArgs(string entityId, ClimateDeviceState state)
+        {
+            EntityId = entityId;
+            State = state;
+        }
+
+        public string EntityId { get; }
+        public ClimateDeviceState State { get; }
+    }
+
+    public sealed class ClimateDeviceRemovedEventArgs : EventArgs
+    {
+        public ClimateDeviceRemovedEventArgs(string entityId)
+        {
+            EntityId = entityId;
+        }
+
+        public string EntityId { get; }
+    }
+}

--- a/HomeAssistantClimate/HomeAssistantClimate.csproj
+++ b/HomeAssistantClimate/HomeAssistantClimate.csproj
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>HomeAssistantClimate</RootNamespace>
+    <TargetFrameworks>net46</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <Deterministic>false</Deterministic>
+    <NoStdLib>true</NoStdLib>
+    <NoConfig>true</NoConfig>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == '' "> 
+    <Configuration>Debug</Configuration>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Web" />
+    <Reference Include="Crestron.DeviceDrivers.SDK.dll">
+      <SpecificVersion>false</SpecificVersion>
+      <HintPath>..\..\..\..\packages\Crestron.DeviceDrivers.SDK\lib\Crestron.DeviceDrivers.SDK.dll</HintPath>
+    </Reference>
+    <Reference Include="Crestron.DeviceDrivers.EntityModel.dll">
+      <SpecificVersion>false</SpecificVersion>
+      <HintPath>..\..\..\..\packages\Crestron.DeviceDrivers.EntityModel\lib\Crestron.DeviceDrivers.EntityModel.dll</HintPath>
+    </Reference>
+    <Reference Include="Crestron.RAD.Common" >
+      <SpecificVersion>false</SpecificVersion>
+      <HintPath>..\..\..\..\packages\RADCommon\lib\RADCommon.dll</HintPath>
+    </Reference>
+    <Reference Include="Crestron.RAD.DeviceTypes.Gateway">
+      <SpecificVersion>false</SpecificVersion>
+      <HintPath>..\..\..\..\packages\Crestron.RAD.DeviceTypes.Gateway\lib\Crestron.RAD.DeviceTypes.Gateway.dll</HintPath>
+    </Reference>
+    <Reference Include="Crestron.RAD.DeviceTypes.Extension">
+      <SpecificVersion>false</SpecificVersion>
+      <HintPath>..\..\..\..\packages\Crestron.RAD.DeviceTypes.Extension\lib\Crestron.RAD.DeviceTypes.Extension.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json">
+      <SpecificVersion>false</SpecificVersion>
+      <HintPath>..\..\..\..\packages\Newtonsoft.Json\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="HomeAssistantPlatform.json" />
+    <EmbeddedResource Include="HomeAssistantClimateDevice.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="EntryPoint.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Definitions\PlatformManagedDevice.cs" />
+    <Compile Include="Gateway\HomeAssistantGateway.cs" />
+    <Compile Include="Gateway\HomeAssistantMessageFactory.cs" />
+    <Compile Include="Gateway\HomeAssistantModels.cs" />
+    <Compile Include="Devices\HomeAssistantClimateDevice.cs" />
+    <Compile Include="HomeAssistantPlatform.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="UiDefinitions\ClimateDeviceUi.xml" />
+    <None Include="UiDefinitions\Translations\en-US.json" />
+  </ItemGroup>
+</Project>

--- a/HomeAssistantClimate/HomeAssistantClimateDevice.json
+++ b/HomeAssistantClimate/HomeAssistantClimateDevice.json
@@ -1,0 +1,16 @@
+{
+  "SchemaVersion": "2.0",
+  "GeneralInformation": {
+    "MinSdkVersion": "22.0000.0000",
+    "DeviceType": "Thermostat",
+    "Manufacturer": "Home Assistant",
+    "BaseModel": "HA Climate",
+    "DriverIdentifier": "HomeAssistantClimateDevice",
+    "SupportedSeries": [ "Crestron Home" ],
+    "DriverVersion": "1.0.0",
+    "VersionDate": "2024-05-01 00:00:00.000"
+  },
+  "UiDefinition": {
+    "Default": "UiDefinitions/ClimateDeviceUi.xml"
+  }
+}

--- a/HomeAssistantClimate/HomeAssistantPlatform.cs
+++ b/HomeAssistantClimate/HomeAssistantPlatform.cs
@@ -1,0 +1,277 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Crestron.DeviceDrivers.EntityModel;
+using Crestron.DeviceDrivers.EntityModel.Data;
+using Crestron.DeviceDrivers.SDK.EntityModel;
+using Crestron.DeviceDrivers.SDK.EntityModel.Attributes;
+using Crestron.DeviceDrivers.SDK;
+using Definitions;
+using HomeAssistantClimate.Devices;
+using HomeAssistantClimate.Gateway;
+
+namespace HomeAssistantClimate
+{
+    public class HomeAssistantPlatform : ReflectedAttributeDriverEntity
+    {
+        private readonly object _syncRoot = new object();
+        private readonly IDictionary<string, HomeAssistantClimateDevice> _climateDevices = new Dictionary<string, HomeAssistantClimateDevice>();
+        private readonly IDictionary<string, PlatformManagedDevice> _managedDevices = new Dictionary<string, PlatformManagedDevice>();
+
+        private HomeAssistantGateway _gateway;
+        private CancellationTokenSource _cts;
+        private bool _isConnected;
+
+        private string _host = string.Empty;
+        private ushort _port = 8123;
+        private bool _useSsl;
+        private string _token = string.Empty;
+
+        public HomeAssistantPlatform(DriverControllerCreationArgs args, DriverImplementationResources resources)
+            : base(DriverController.RootControllerId)
+        {
+            var cfgArgs = DataDrivenConfigurationControllerArgs.FromResources(args, resources, ControllerId);
+            ConfigurationController = new DelegateDataDrivenConfigurationController(cfgArgs, ApplyConfigurationItems, null, null);
+        }
+
+        internal DataDrivenConfigurationController ConfigurationController { get; }
+
+        [EntityProperty(
+            Id = "platform:managedDevices",
+            Type = DriverEntityValueType.DeviceDictionary,
+            ItemTypeRef = "platform:ManagedDevice"
+        )]
+        public IDictionary<string, PlatformManagedDevice> ManagedDevices
+        {
+            get
+            {
+                lock (_syncRoot)
+                {
+                    return new Dictionary<string, PlatformManagedDevice>(_managedDevices);
+                }
+            }
+        }
+
+        private ConfigurationItemErrors ApplyConfigurationItems(
+            DataDrivenConfigurationController.ApplyConfigurationAction action,
+            string stepId,
+            IDictionary<string, DriverEntityValue?> values)
+        {
+            switch (action)
+            {
+                case DataDrivenConfigurationController.ApplyConfigurationAction.ApplyAll:
+                case DataDrivenConfigurationController.ApplyConfigurationAction.ApplyStep:
+                    return ApplyConfiguration(values);
+                case DataDrivenConfigurationController.ApplyConfigurationAction.ClearValues:
+                    StopGateway();
+                    break;
+            }
+
+            return null;
+        }
+
+        private ConfigurationItemErrors ApplyConfiguration(IDictionary<string, DriverEntityValue?> values)
+        {
+            if (values == null)
+            {
+                return new ConfigurationItemErrors(new Dictionary<string, string> { { "_Host_", "Host is required" } }, null);
+            }
+
+            var errors = new Dictionary<string, string>();
+
+            if (values.TryGetValue("_Host_", out var hostValue) && hostValue.HasValue)
+            {
+                _host = hostValue.Value.GetValue<string>();
+            }
+            else if (string.IsNullOrWhiteSpace(_host))
+            {
+                errors["_Host_"] = "Host is required";
+            }
+
+            if (values.TryGetValue("_Port_", out var portValue) && portValue.HasValue)
+            {
+                var parsedPort = (ushort)portValue.Value.GetValue<long>();
+                if (parsedPort == 0)
+                {
+                    errors["_Port_"] = "Port must be greater than 0";
+                }
+                else
+                {
+                    _port = parsedPort;
+                }
+            }
+
+            if (values.TryGetValue("UseSsl", out var sslValue) && sslValue.HasValue)
+            {
+                _useSsl = sslValue.Value.GetValue<bool>();
+            }
+
+            if (values.TryGetValue("AccessToken", out var tokenValue) && tokenValue.HasValue)
+            {
+                _token = tokenValue.Value.GetValue<string>();
+            }
+
+            if (string.IsNullOrWhiteSpace(_token))
+            {
+                errors["AccessToken"] = "Long lived access token is required";
+            }
+
+            if (errors.Any())
+            {
+                return new ConfigurationItemErrors(errors, null);
+            }
+
+            StartGateway();
+            return null;
+        }
+
+        private void StartGateway()
+        {
+            StopGateway();
+
+            if (string.IsNullOrWhiteSpace(_host) || string.IsNullOrWhiteSpace(_token))
+            {
+                return;
+            }
+
+            var uriBuilder = new UriBuilder
+            {
+                Host = _host,
+                Scheme = _useSsl ? "wss" : "ws",
+                Port = _port,
+                Path = "/api/websocket"
+            };
+
+            _cts = new CancellationTokenSource();
+
+            _gateway = new HomeAssistantGateway(uriBuilder.Uri, _token);
+            _gateway.ClimateDeviceDiscovered += GatewayOnClimateDeviceDiscovered;
+            _gateway.ClimateDeviceRemoved += GatewayOnClimateDeviceRemoved;
+            _gateway.ClimateDeviceUpdated += GatewayOnClimateDeviceUpdated;
+            _gateway.ConnectionStateChanged += GatewayOnConnectionStateChanged;
+
+            Task.Run(() => _gateway.StartAsync(_cts.Token));
+        }
+
+        private void StopGateway()
+        {
+            _isConnected = false;
+
+            if (_gateway != null)
+            {
+                _gateway.ClimateDeviceDiscovered -= GatewayOnClimateDeviceDiscovered;
+                _gateway.ClimateDeviceRemoved -= GatewayOnClimateDeviceRemoved;
+                _gateway.ClimateDeviceUpdated -= GatewayOnClimateDeviceUpdated;
+                _gateway.ConnectionStateChanged -= GatewayOnConnectionStateChanged;
+                _gateway.Dispose();
+                _gateway = null;
+            }
+
+            if (_cts != null)
+            {
+                _cts.Cancel();
+                _cts.Dispose();
+                _cts = null;
+            }
+
+            lock (_syncRoot)
+            {
+                var controllerIds = _climateDevices.Keys.ToArray();
+                if (controllerIds.Length > 0)
+                {
+                    UpdateSubControllers(null, controllerIds);
+                }
+
+                foreach (var device in _climateDevices.Values)
+                {
+                    device.Dispose();
+                }
+
+                _climateDevices.Clear();
+                _managedDevices.Clear();
+
+                NotifyPropertyChanged("platform:managedDevices", CreateValueForEntries(_managedDevices));
+            }
+        }
+
+        private void GatewayOnConnectionStateChanged(object sender, bool e)
+        {
+            _isConnected = e;
+
+            lock (_syncRoot)
+            {
+                foreach (var device in _climateDevices.Values)
+                {
+                    device.SetConnectionState(e);
+                }
+            }
+        }
+
+        private void GatewayOnClimateDeviceDiscovered(object sender, ClimateDeviceDiscoveredEventArgs e)
+        {
+            lock (_syncRoot)
+            {
+                if (_climateDevices.TryGetValue(e.EntityId, out var existing))
+                {
+                    existing.SetConnectionState(_isConnected);
+                    existing.UpdateFromState(e.State);
+                    return;
+                }
+
+                var device = new HomeAssistantClimateDevice(e.EntityId, e.FriendlyName, _gateway);
+                device.SetConnectionState(_isConnected);
+                device.UpdateFromState(e.State);
+
+                _climateDevices[e.EntityId] = device;
+
+                var managedDevice = new PlatformManagedDevice(DeviceUxCategory.Hvac, e.FriendlyName, "Home Assistant", e.Model, e.EntityId);
+                _managedDevices[e.EntityId] = managedDevice;
+
+                var subControllers = new[]
+                {
+                    new ConfigurableDriverEntity(device.ControllerId, device, null)
+                };
+
+                UpdateSubControllers(subControllers, null);
+
+                NotifyPropertyChanged("platform:managedDevices", CreateValueForEntries(_managedDevices));
+            }
+        }
+
+        private void GatewayOnClimateDeviceUpdated(object sender, ClimateDeviceUpdatedEventArgs e)
+        {
+            lock (_syncRoot)
+            {
+                if (_climateDevices.TryGetValue(e.EntityId, out var device))
+                {
+                    device.UpdateFromState(e.State);
+                }
+            }
+        }
+
+        private void GatewayOnClimateDeviceRemoved(object sender, ClimateDeviceRemovedEventArgs e)
+        {
+            lock (_syncRoot)
+            {
+                if (_climateDevices.Remove(e.EntityId, out var device))
+                {
+                    device.Dispose();
+                    UpdateSubControllers(null, new[] { device.ControllerId });
+                }
+
+                if (_managedDevices.Remove(e.EntityId))
+                {
+                    NotifyPropertyChanged("platform:managedDevices", CreateValueForEntries(_managedDevices));
+                }
+            }
+        }
+
+        public override void Dispose()
+        {
+            StopGateway();
+            base.Dispose();
+        }
+    }
+}

--- a/HomeAssistantClimate/HomeAssistantPlatform.json
+++ b/HomeAssistantClimate/HomeAssistantPlatform.json
@@ -1,0 +1,73 @@
+{
+  "SchemaVersion": "2.0",
+  "GeneralInformation": {
+    "MinSdkVersion": "22.0000.0000",
+    "DeviceType": "Platform",
+    "Manufacturer": "Home Assistant",
+    "BaseModel": "Home Assistant Bridge",
+    "DriverIdentifier": "HomeAssistantClimatePlatform",
+    "SupportedSeries": [ "Crestron Home" ],
+    "DriverVersion": "1.0.0",
+    "VersionDate": "2024-05-01 00:00:00.000",
+    "Developer": {
+      "Company": "Home Assistant Community",
+      "Contact": "Integrations Team",
+      "Email": "integrations@example.com"
+    }
+  },
+  "Communication": {
+    "CommunicationType": 1,
+    "IpProtocol": 0,
+    "DefaultPort": 8123,
+    "IsUserAdjustable": true,
+    "SupportsSsl": true
+  },
+  "ConfigurationSteps": {
+    "Items": [
+      {
+        "Id": "_Host_",
+        "UsageContext": "Network.Address",
+        "Title": "Home Assistant Host",
+        "Required": true,
+        "ValueType": "String"
+      },
+      {
+        "Id": "_Port_",
+        "UsageContext": "Network.Port",
+        "Title": "WebSocket Port",
+        "Required": true,
+        "MaxValue": 65535,
+        "MinValue": 1,
+        "Persistent": true,
+        "ValueType": "Number",
+        "DefaultValue": "8123"
+      },
+      {
+        "Id": "UseSsl",
+        "Title": "Use Secure WebSocket (WSS)",
+        "Required": false,
+        "ValueType": "Boolean",
+        "DefaultValue": false
+      },
+      {
+        "Id": "AccessToken",
+        "Title": "Long-Lived Access Token",
+        "Required": true,
+        "ValueType": "Password"
+      }
+    ],
+    "Steps": [
+      {
+        "StepId": "Connection",
+        "Items": [ "_Host_", "_Port_", "UseSsl", "AccessToken" ]
+      }
+    ],
+    "FirstStep": "Connection"
+  },
+  "Dependencies": [
+    {
+      "AssemblyName": "HomeAssistantClimate",
+      "DriverData": "HomeAssistantClimateDevice.json"
+    }
+  ]
+}

--- a/HomeAssistantClimate/Properties/AssemblyInfo.cs
+++ b/HomeAssistantClimate/Properties/AssemblyInfo.cs
@@ -1,0 +1,14 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("HomeAssistantClimate")] 
+[assembly: AssemblyDescription("Crestron Home platform driver for Home Assistant climate entities")] 
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Home Assistant")] 
+[assembly: AssemblyProduct("HomeAssistantClimate")] 
+[assembly: AssemblyCopyright("Copyright © 2024")] 
+[assembly: AssemblyTrademark("")] 
+[assembly: AssemblyCulture("")] 
+[assembly: ComVisible(false)]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/HomeAssistantClimate/UiDefinitions/ClimateDeviceUi.xml
+++ b/HomeAssistantClimate/UiDefinitions/ClimateDeviceUi.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<uidefinition xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://prd-use-rad-assets.azurewebsites.net/ExtensionsSchemaDefinition.xsd">
+  <version ver="2.0" />
+
+  <tile icon="#icClimate" status="{climate:currentTemperature}°" action="show:Main" navigation="show:Main" showinhomepage="#true" showinroompage="#true" />
+
+  <layouts>
+    <layout id="Main" isdefaultlayout="#true">
+      <controls>
+        <textdisplay id="Header" title="{climate:friendlyName}" line1label="^CurrentTemperatureLabel" line1value="{climate:currentTemperature}°" line2label="^TargetTemperatureLabel" line2value="{climate:targetTemperature}°" />
+        <textdisplay id="Mode" title="^ModeTitle" line1label="^ModeLabel" line1value="{climate:hvacMode}" line2label="^ActionLabel" line2value="{climate:hvacAction}" />
+        <textdisplay id="Humidity" title="^HumidityTitle" line1label="^HumidityLabel" line1value="{climate:humidity}%" />
+        <button id="Decrease" label="^DecreaseButton" action="command:climate:decreaseSetpoint" />
+        <button id="Increase" label="^IncreaseButton" action="command:climate:increaseSetpoint" />
+        <button id="Heat" label="^HeatButton" action="command:climate:setHvacMode" parameters="heat" />
+        <button id="Cool" label="^CoolButton" action="command:climate:setHvacMode" parameters="cool" />
+        <button id="Auto" label="^AutoButton" action="command:climate:setHvacMode" parameters="auto" />
+        <button id="Off" label="^OffButton" action="command:climate:setHvacMode" parameters="off" />
+      </controls>
+    </layout>
+  </layouts>
+
+  <alerts>
+  </alerts>
+</uidefinition>

--- a/HomeAssistantClimate/UiDefinitions/Translations/en-US.json
+++ b/HomeAssistantClimate/UiDefinitions/Translations/en-US.json
@@ -1,0 +1,15 @@
+{
+  "CurrentTemperatureLabel": "Current",
+  "TargetTemperatureLabel": "Target",
+  "ModeTitle": "System",
+  "ModeLabel": "Mode",
+  "ActionLabel": "Action",
+  "HumidityTitle": "Humidity",
+  "HumidityLabel": "Relative",
+  "DecreaseButton": "Lower",
+  "IncreaseButton": "Raise",
+  "HeatButton": "Heat",
+  "CoolButton": "Cool",
+  "AutoButton": "Auto",
+  "OffButton": "Off"
+}


### PR DESCRIPTION
## Summary
- update thermostat command handlers to normalize incoming values and immediately publish property feedback before sending Home Assistant commands
- add shared helpers for safely parsing numeric and string DriverEntityValue inputs to avoid invalid conversions during UI interactions

## Testing
- dotnet build HomeAssistantClimate/HomeAssistantClimate.csproj *(fails: dotnet is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd6d72f8b8832da651aa36eb7bf812